### PR TITLE
Update getIndexHash.ts

### DIFF
--- a/src/server/utils/getIndexHash.ts
+++ b/src/server/utils/getIndexHash.ts
@@ -22,7 +22,7 @@ export function getIndexHash(config: ProcessedPluginOptions): string | null {
         } else if (!fs.lstatSync(dir).isDirectory()) {
           console.warn(`Warn: \`${dirField}\` is not a directory: "${dir}".`);
         } else {
-          files.push(...klawSync(dir, { nodir: true, filter: markdownFilter }));
+          files.push(...klawSync(dir, { nodir: true, filter: markdownFilter, traverseAll: true }));
         }
       }
     }
@@ -57,5 +57,5 @@ export function getIndexHash(config: ProcessedPluginOptions): string | null {
 }
 
 function markdownFilter(item: klawSync.Item): boolean {
-  return item.path.endsWith(".md");
+  return item.path.endsWith(".md") || item.path.endsWith(".mdx");
 }


### PR DESCRIPTION
- Includes `.mdx` files in the markdown-filter
  This is needed because documentation could be either `.md` files or `.mdx` files, both type of files should be accounted for generating the hash
  https://docusaurus.io/docs/markdown-features/plugins
- add `traverseAll: true`
  This is needed because `docs/` could be organized by subfolders (or categories)
  https://docusaurus.io/docs/sidebar/autogenerated#category-index-convention
  <img width="681" alt="image" src="https://user-images.githubusercontent.com/9648559/168846543-59ab420f-ea23-4d00-87b5-7c3ee91dd1b3.png">
